### PR TITLE
feat: local file storage and init_db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2136,6 +2136,8 @@ name = "nutrack-database"
 version = "0.1.0"
 dependencies = [
  "rusqlite",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3028,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -3840,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",

--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ npm run tauri build
 ```bash
 cd src-tauri && cargo build
 ```
+
+- Run database rust tests exclusively:
+
+```bash
+cd src-rust-crates/database && cargo test
+```

--- a/src-rust-crates/database/Cargo.toml
+++ b/src-rust-crates/database/Cargo.toml
@@ -6,3 +6,7 @@ license.workspace = true
 
 [dependencies]
 rusqlite = "0.38.0"
+thiserror = "2.0.18"
+
+[dev-dependencies]
+tempfile = "3.26.0"

--- a/src-rust-crates/database/src/lib.rs
+++ b/src-rust-crates/database/src/lib.rs
@@ -1,14 +1,44 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use rusqlite::Connection;
+use std::path::Path;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("Failed to connect to database: {0}")]
+    ConnectionError(#[from] rusqlite::Error),
+    #[error("Failed to access storage path: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+/// Initializes the database at the securely provided file path.
+/// Handles required directory creation mapping securely inside Tauri.
+pub fn init_db(db_path: &Path) -> Result<Connection, DatabaseError> {
+    // Attempt to create the parent directory if it does not exist (e.g. initial launch)
+    if let Some(parent) = db_path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    // Open or create the SQLite connection
+    let conn = Connection::open(db_path)?;
+    Ok(conn)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn test_db_initialization() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        // Test creation
+        let result = init_db(&db_path);
+        assert!(result.is_ok(), "Database should initialize successfully");
+        assert!(db_path.exists(), "Database file should be created");
+
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,52 @@
+use std::sync::Mutex;
+use tauri::Manager;
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+#[tauri::command]
+fn get_db_path(app: tauri::AppHandle) -> Result<String, String> {
+    // This is added as a temporary function to test the local sqlite database
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to locate app data directory: {}", e))?;
+        
+    let db_path = app_data_dir.join("nutrition.db");
+    
+    Ok(db_path.to_string_lossy().into_owned())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .setup(|app| {
+            // Resolve the platform-specific AppData directory dynamically
+            let app_data_dir = app
+                .path()
+                .app_data_dir()
+                .map_err(|e| {
+                    Box::<dyn std::error::Error>::from(format!("Failed to locate app data directory on this OS: {}", e))
+                })?;
+
+            let db_path = app_data_dir.join("nutrition.db");
+
+            // Init the database explicitly without unwrap/expect
+            let conn = nutrack_database::init_db(&db_path)
+                .map_err(|e| Box::<dyn std::error::Error>::from(format!("Failed to initialize: {}", e)))?;
+                
+            println!("Successfully initialized DB at: {:?}", db_path);
+            
+            // Manage connection state for commands safely using Mutex
+            app.manage(Mutex::new(conn));
+
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![greet, get_db_path])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import "./App.css";
 function App() {
   const [greetMsg, setGreetMsg] = useState("");
   const [name, setName] = useState("");
+  const [dbPath, setDbPath] = useState("");
 
   async function greet() {
     // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
@@ -44,6 +45,27 @@ function App() {
         <button type="submit">Greet</button>
       </form>
       <p>{greetMsg}</p>
+
+      <hr style={{ margin: "2rem 0", width: "100%", borderColor: "#333" }} />
+        <h2>Database Location Demo</h2>
+      <div className="row">
+        <button onClick={async () => {
+          try {
+            const path: string = await invoke("get_db_path");
+            setDbPath(path);
+          } catch (e) {
+            setDbPath(`Error: ${e}`);
+          }
+        }}>
+          Show Database Location
+        </button>
+      </div>
+      {dbPath && (
+        <p>
+          {dbPath}
+        </p>
+      )}
+
     </main>
   );
 }


### PR DESCRIPTION
## Feature: Local SQLite File Storage with `init_db` function (Ticket #9 )

### Description
This PR implements local file storage and permission handling for the database schema. It correctly establishes the SQLite connection through the Rust workspace crate and isolates database operations cleanly behind Tauri's State manager.

### Key Changes
- **Crate Integration**: Added `rusqlite` and `thiserror` to the `nutrack-database` workspace.
- **Secure Initialization**: Added `init_db` logic to dynamically create missing parent directories and establish SQLite connections gracefully.
- **Tauri Resolver**: Bound DB initialization to `app_data_dir()` inside Tauri's `setup()` hook. Permissions are now securely mapped to the OS App Support directory. 
- **Thread Safety**: Wrapped the database connection in `std::sync::Mutex` and injected it into `app.manage()`, setting the foundation for thread-safe concurrent queries later.
- **Demo & Testing**: 
  - Added a "Show Database Location" UI button leveraging a newly exposed `get_db_path()` Tauri command to verify paths in React.
  - Implemented isolated unit testing in Rust via the `tempfile` crate.
  - Updated `README.md` with instructions on how to test the database crate.
