### PR TITLE
chore(ci): create nightly build ci script placeholder

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,26 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: "Build even if main has not been updated in the last 24 hours"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nightly-release
+  cancel-in-progress: false
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "CI placeholder"


### PR DESCRIPTION
This placeholder does nothing, it only creates an entry so that we can gradually write and test this ci script in another branch