### PR TITLE
feat(5.2/5.6/5.9): theme system, toast notifications, export feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import Insights from "./pages/Insights";
 import AiAdvisor from "./pages/AiAdvisor";
 import Settings from "./pages/Settings";
 import { NetworkProvider } from "./lib/NetworkContext";
+import { ThemeProvider } from "./lib/ThemeContext";
+import { ToastProvider } from "./lib/ToastContext";
 import {
   DatabaseSessionProvider,
   useDatabaseSession,
@@ -40,11 +42,15 @@ function RoutedApp() {
 
 function App() {
   return (
-    <NetworkProvider>
-      <DatabaseSessionProvider>
-        <RoutedApp />
-      </DatabaseSessionProvider>
-    </NetworkProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <NetworkProvider>
+          <DatabaseSessionProvider>
+            <RoutedApp />
+          </DatabaseSessionProvider>
+        </NetworkProvider>
+      </ToastProvider>
+    </ThemeProvider>
   );
 }
 

--- a/src/lib/ThemeContext.tsx
+++ b/src/lib/ThemeContext.tsx
@@ -1,0 +1,48 @@
+// src/lib/ThemeContext.tsx
+// Sprint 5.9 — Theme system (dark / light)
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+export type Theme = "dark" | "light";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const LS_KEY = "nutrilog.theme.v1";
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const saved = localStorage.getItem(LS_KEY);
+    return saved === "light" ? "light" : "dark";
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem(LS_KEY, theme);
+  }, [theme]);
+
+  function setTheme(t: Theme) {
+    setThemeState(t);
+  }
+
+  function toggleTheme() {
+    setThemeState((prev) => (prev === "dark" ? "light" : "dark"));
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used inside ThemeProvider");
+  return ctx;
+}

--- a/src/lib/ToastContext.tsx
+++ b/src/lib/ToastContext.tsx
@@ -1,0 +1,86 @@
+// src/lib/ToastContext.tsx
+// Sprint 5.6 — Global toast notification system
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+
+export type ToastType = "success" | "error" | "info";
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastContextValue {
+  showToast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = useCallback((message: string, type: ToastType = "info") => {
+    const id = crypto.randomUUID();
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3500);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {/* Toast container */}
+      <div style={{
+        position: "fixed",
+        bottom: 24,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 9999,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        alignItems: "center",
+        pointerEvents: "none",
+      }}>
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            style={{
+              padding: "10px 18px",
+              borderRadius: 12,
+              fontSize: 13,
+              fontWeight: 500,
+              color: "rgba(255,255,255,0.95)",
+              backdropFilter: "blur(12px)",
+              boxShadow: "0 8px 24px rgba(0,0,0,0.35)",
+              animation: "fadeSlideUp 0.25s ease",
+              pointerEvents: "auto",
+              border: "1px solid",
+              ...(t.type === "success" ? {
+                background: "rgba(40,180,100,0.85)",
+                borderColor: "rgba(40,180,100,0.5)",
+              } : t.type === "error" ? {
+                background: "rgba(220,60,60,0.85)",
+                borderColor: "rgba(220,60,60,0.5)",
+              } : {
+                background: "rgba(30,30,40,0.90)",
+                borderColor: "rgba(255,255,255,0.12)",
+              }),
+            }}
+          >
+            {t.type === "success" ? "✅ " : t.type === "error" ? "⚠️ " : "ℹ️ "}
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used inside ToastProvider");
+  return ctx;
+}

--- a/src/pages/AiAdvisor.tsx
+++ b/src/pages/AiAdvisor.tsx
@@ -43,6 +43,7 @@ interface ChatMessage {
   content: string;
   nlogData?: string;
   tokens?: number;
+  provider?: string;
 }
 
 interface GoalOption {
@@ -1172,8 +1173,37 @@ export default function AiAdvisor() {
             key={i}
             className={`card ai-chat-bubble ${msg.role === "assistant" ? "ai-chat-assistant" : "ai-chat-user"}`}
           >
-            <div className="ai-chat-role">
-              {msg.role === "user" ? "You" : "NutriLog AI"}
+            <div className="ai-chat-role" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              {msg.role === "user" ? "You" : (
+                <>
+                  <span>🤖 NutriLog AI</span>
+                  {msg.provider && (
+                    <span style={{
+                      fontSize: 10,
+                      fontWeight: 600,
+                      padding: "2px 7px",
+                      borderRadius: 6,
+                      background: "rgba(124,92,255,0.15)",
+                      border: "1px solid rgba(124,92,255,0.3)",
+                      color: "rgba(124,92,255,0.9)",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.05em",
+                    }}>
+                      {msg.provider}
+                    </span>
+                  )}
+                  <span style={{
+                    fontSize: 10,
+                    padding: "2px 7px",
+                    borderRadius: 6,
+                    background: "rgba(255,255,255,0.06)",
+                    border: "1px solid rgba(255,255,255,0.1)",
+                    color: "var(--muted2)",
+                  }}>
+                    AI Generated
+                  </span>
+                </>
+              )}
             </div>
             {msg.role === "assistant" ? (
               <div className="ai-markdown" style={{ fontSize: 14, lineHeight: 1.7 }}>
@@ -1203,8 +1233,11 @@ export default function AiAdvisor() {
             )}
 
             {msg.tokens !== undefined && msg.tokens > 0 && (
-              <div className="ai-chat-tokens">
-                {msg.tokens} tokens used
+              <div className="ai-chat-tokens" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <span>⚡ {msg.tokens} tokens</span>
+                {msg.provider && (
+                  <span style={{ color: "var(--muted2)" }}>· via {msg.provider}</span>
+                )}
               </div>
             )}
           </div>
@@ -1238,12 +1271,12 @@ export default function AiAdvisor() {
 
       {/* Sliding Grocery List Panel */}
       {isGroceryOpen && (
-        <div 
-          className="card" 
-          style={{ 
-            width: 280, 
-            borderLeft: "1px solid var(--border)", 
-            background: "rgba(20, 22, 30, 0.95)", 
+        <div
+          className="card"
+          style={{
+            width: 280,
+            borderLeft: "1px solid var(--border)",
+            background: "rgba(20, 22, 30, 0.95)",
             flexShrink: 0,
             animation: "fadeSlideLeft 0.2s ease-out",
             border: "none",
@@ -1256,7 +1289,7 @@ export default function AiAdvisor() {
           <div style={{ fontWeight: 700, fontSize: 14, marginBottom: 12, paddingBottom: 10, borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
             <span style={{ color: "#10b981" }}>🛒 Smart Grocery List</span>
             <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-              <button 
+              <button
                 onClick={clearGroceryList}
                 style={{ background: "none", border: "none", color: "var(--muted2)", fontSize: 10, cursor: "pointer", textTransform: "uppercase", letterSpacing: "0.05em" }}
               >

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,6 +3,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { save } from "@tauri-apps/plugin-dialog";
 import ProfileForm from "../components/ProfileForm";
 import { useUserProfile } from "../hooks/useUserProfile";
+import { useTheme } from "../lib/ThemeContext";
+import { useToast } from "../lib/ToastContext";
 import { useDatabaseSession } from "../lib/DatabaseSessionContext";
 import {
   useCredentials,
@@ -18,17 +20,16 @@ import "../styles/credentials.css";
 
 export default function Settings() {
   const { session } = useDatabaseSession();
+  const { theme, setTheme } = useTheme();
   const { profile, loading, saving, error, computed, persist, reset } =
     useUserProfile();
   const [exporting, setExporting] = useState(false);
-  const [exportMessage, setExportMessage] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   async function handleExportXlsx() {
-    setExportMessage(null);
-
     const connectedPath = session.connectedPath?.trim();
     if (!connectedPath) {
-      setExportMessage("No database is currently connected.");
+      showToast("No database is currently connected.", "error");
       return;
     }
 
@@ -47,10 +48,11 @@ export default function Settings() {
       const writtenPath = await invoke<string>("export_xlsx_to_path", {
         path: selectedPath,
       });
-      setExportMessage(`Exported database to ${writtenPath}`);
+      showToast(`Exported to ${writtenPath}`, "success");
     } catch (err) {
-      setExportMessage(
+      showToast(
         err instanceof Error ? err.message : "Failed to export database",
+        "error"
       );
     } finally {
       setExporting(false);
@@ -140,6 +142,52 @@ export default function Settings() {
           </div>
         )}
       </div>
+      <div className="card pop-in-delay-1" style={{ maxWidth: 720 }}>
+        <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 4 }}>Appearance</div>
+        <div style={{ fontSize: 13, color: "var(--muted)", marginBottom: 14 }}>
+          Choose your preferred color theme.
+        </div>
+        <div style={{ display: "flex", gap: 10 }}>
+          <button
+            onClick={() => setTheme("dark")}
+            style={{
+              flex: 1,
+              padding: "10px 14px",
+              borderRadius: 12,
+              border: `1px solid ${theme === "dark" ? "rgba(124,92,255,0.5)" : "var(--border)"}`,
+              background: theme === "dark"
+                ? "linear-gradient(135deg, rgba(124,92,255,0.2), rgba(0,209,255,0.08))"
+                : "rgba(255,255,255,0.04)",
+              color: "var(--text)",
+              cursor: "pointer",
+              fontWeight: theme === "dark" ? 700 : 400,
+              fontSize: 13,
+              fontFamily: "inherit",
+            }}
+          >
+            🌙 Dark
+          </button>
+          <button
+            onClick={() => setTheme("light")}
+            style={{
+              flex: 1,
+              padding: "10px 14px",
+              borderRadius: 12,
+              border: `1px solid ${theme === "light" ? "rgba(124,92,255,0.5)" : "var(--border)"}`,
+              background: theme === "light"
+                ? "linear-gradient(135deg, rgba(124,92,255,0.2), rgba(0,209,255,0.08))"
+                : "rgba(255,255,255,0.04)",
+              color: "var(--text)",
+              cursor: "pointer",
+              fontWeight: theme === "light" ? 700 : 400,
+              fontSize: 13,
+              fontFamily: "inherit",
+            }}
+          >
+            ☀️ Light
+          </button>
+        </div>
+      </div>
 
       <div className="card pop-in-delay-1" style={{ maxWidth: 720 }}>
         <div style={{ fontSize: 16, fontWeight: 600 }}>Database export</div>
@@ -182,19 +230,8 @@ export default function Settings() {
           </button>
         </div>
 
-        {exportMessage && (
-          <div
-            style={{
-              marginTop: 12,
-              fontSize: 12,
-              color: exportMessage.startsWith("Exported")
-                ? "var(--muted)"
-                : "#ff9a9a",
-            }}
-          >
-            {exportMessage}
-          </div>
-        )}
+
+
       </div>
 
       {/* ── AI Provider Configuration ── */}
@@ -668,7 +705,7 @@ function ApiKeySection() {
         <div className="ai-config-subtitle" style={{ marginBottom: 16 }}>
           The AI automatically learns preferences and facts about you from your conversations to personalize advice. You can review and delete them here.
         </div>
-        
+
         {loadingMemories ? (
           <div style={{ color: "var(--muted2)", fontSize: 13 }}>Loading your AI memories...</div>
         ) : memories.length === 0 ? (
@@ -680,7 +717,7 @@ function ApiKeySection() {
             {memories.map(m => (
               <div key={m.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "10px 14px", background: "rgba(0,0,0,0.2)", border: "1px solid rgba(255,255,255,0.03)", borderRadius: 8 }}>
                 <span style={{ fontSize: 14, color: "var(--text)" }}>{m.fact}</span>
-                <button 
+                <button
                   onClick={() => handleRemoveMemory(m.id)}
                   style={{ background: "none", border: "none", cursor: "pointer", color: "var(--muted2)", padding: 4 }}
                   title="Delete memory"

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12,6 +12,24 @@
   --radius-sm: 12px;
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
 }
+/* ── Light theme ─────────────────────────────────────────────────────────── */
+[data-theme="light"] {
+  --bg:     #f0f2f7;
+  --panel:  rgba(0,0,0,0.04);
+  --panel2: rgba(0,0,0,0.06);
+  --border: rgba(0,0,0,0.10);
+  --text:   rgba(0,0,0,0.88);
+  --muted:  rgba(0,0,0,0.55);
+  --muted2: rgba(0,0,0,0.38);
+  --accent: #7c5cff;
+  --shadow: 0 18px 40px rgba(0,0,0,0.10);
+}
+
+[data-theme="light"] body::before {
+  background: radial-gradient(1200px 700px at 20% -10%, rgba(124,92,255,0.08), transparent 55%),
+              radial-gradient(1000px 650px at 90% 0%, rgba(0,209,255,0.06), transparent 55%),
+              var(--bg);
+}
 
 *{ box-sizing: border-box; }
 html, body { height: 100%; }


### PR DESCRIPTION
Sprint 5.9 — Dark mode and theme system:
- Added light/dark theme toggle in Settings → Appearance
- ThemeContext persists theme preference to localStorage
- Light theme CSS variables defined in app.css via [data-theme="light"]

Sprint 5.6 — Error handling and loading feedback:
- Added global ToastProvider with success/error/info toast types
- Toasts auto-dismiss after 3.5 seconds
- Animated, positioned at bottom center of screen

Sprint 5.2 — Export interface:
- Export as XLSX now shows success toast with file path
- Export errors show error toast
- Removed inline exportMessage state, unified with toast system